### PR TITLE
MAZeroingWeakRef: Fix compile error after pod update

### DIFF
--- a/MAZeroingWeakRef/1.0/MAZeroingWeakRef.podspec
+++ b/MAZeroingWeakRef/1.0/MAZeroingWeakRef.podspec
@@ -12,8 +12,9 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/mikeash/MAZeroingWeakRef.git", :tag => "1.0" }
 
   s.ios.deployment_target = '4.0'
-  s.osx.deployment_target = '10.5'
+  s.osx.deployment_target = '10.6'
   s.source_files = 'Source/MA*.{h,m}'
   s.exclude_files = 'Source/main.m'
   s.private_header_files = 'Source/MAZeroingWeakRefNativeZWRNotAllowedTable.h'
+  s.requires_arc = false
 end


### PR DESCRIPTION
The `MAZeroingWeakRef` pod started causing problems with more recent versions of CocoaPods. It was the same symptom as outlined in https://github.com/CocoaPods/CocoaPods/issues/4952

> clang: error: -fobjc-arc is not supported on versions of OS X prior to 10.6

This PR updates the OSX deployment target to 10.6 and removes ARC. Both changes are needed for it to compile - I have tested with either/or and it was insufficient.
